### PR TITLE
chore(ci): add CI workflow using Node 18

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Start dev (sanity)
+        run: |
+          npm run dev -- --hostname 127.0.0.1 --port 3000 &
+          sleep 3
+          curl -sSf http://127.0.0.1:3000/ || true


### PR DESCRIPTION
CI（GitHub Actions）の Node バージョンを >=18 に切り替える