### PR TITLE
feat(login): ログイン画面からパスワード再設定メールを送信

### DIFF
--- a/src/components/templates/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate.tsx
@@ -7,7 +7,7 @@ import {useRouter} from 'next/router'
 import {TextInput} from '../Inputs'
 import {PrimaryButton} from '../Buttons'
 import {useStringChangeEvent} from '../../lib/customHooks'
-import {logIn} from '../../lib/auth'
+import {logIn, sendPasswordReset} from '../../lib/auth'
 
 const LoginTemplate:VFC = () => {
   const router = useRouter()
@@ -23,6 +23,20 @@ const LoginTemplate:VFC = () => {
       alert(handle)
     },
   })
+
+  const resetMutate = useMutation(sendPasswordReset, {
+    onSuccess: () => {
+      alert(
+        'パスワード再設定用のメールを送信しました。メール内のリンクから新しいパスワードを設定してください。'
+      )
+    },
+    onError: () => {
+      alert(
+        '再設定メールの送信に失敗しました。登録済みのメールアドレスかご確認ください。'
+      )
+    },
+  })
+
   return (
     <Container maxWidth='sm' component="main">
       <Box
@@ -47,6 +61,15 @@ const LoginTemplate:VFC = () => {
           <TextInput type={'password'} placeholder={'半角6文字以上で入力'} label={'Password'} onChange={useStringChangeEvent(setPassword)} value={password}/>
         </Box>
         <PrimaryButton text={'login'} onClick={() => loginMutate.mutate({email,password})}/>
+        <Box sx={{width:'100%', marginTop: 2}}>
+          <PrimaryButton
+            text={'パスワードを忘れた方（再設定メールを送る）'}
+            variant={'text'}
+            color={'inherit'}
+            disabled={resetMutate.isLoading}
+            onClick={() => resetMutate.mutate(email)}
+          />
+        </Box>
       </Box>
     </Container>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -64,6 +64,28 @@ export const logIn = ( user:{ email : string , password : string } ): Promise<st
   })
 }
 
+export const sendPasswordReset = (email: string): Promise<string | undefined> => {
+  return new Promise((resolve, reject) => {
+    if (!isValidRequiredInput(email, 'メールアドレス')) {
+      reject(undefined)
+      return
+    }
+    if (!isValidEmailFormat(email)) {
+      reject(undefined)
+      return
+    }
+    auth
+      .sendPasswordResetEmail(email)
+      .then(() => {
+        resolve('Success')
+      })
+      .catch((error) => {
+        console.error(error)
+        reject(error)
+      })
+  })
+}
+
 export const logOut = (): Promise<string | undefined> => {
   return new Promise((resolve, reject) => {
     auth


### PR DESCRIPTION
Closes #31

## Summary
- `sendPasswordResetEmail` を追加
- ログイン画面に再設定メール送信ボタンを追加

## Test plan
- [ ] `/login` でメール入力後、再設定ボタンでメールが届く