### PR TITLE
fix(auth): ログイン後に auth クエリが更新されず /login に戻る

### DIFF
--- a/src/components/templates/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate.tsx
@@ -1,7 +1,7 @@
 import {VFC,useState} from 'react';
 import { Container,Box,Avatar,Typography,CssBaseline } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
-import {useMutation} from 'react-query'
+import {useMutation, useQueryClient} from 'react-query'
 import {useRouter} from 'next/router'
 
 import {TextInput} from '../Inputs'
@@ -11,11 +11,13 @@ import {logIn} from '../../lib/auth'
 
 const LoginTemplate:VFC = () => {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const [email,setEmail] = useState('')
   const [password,setPassword] = useState('')
 
   const loginMutate = useMutation(logIn, {
-    onSuccess:() => {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries('auth')
       router.push('/')
     },
     onError: (error) => {

--- a/src/components/utility/Auth.tsx
+++ b/src/components/utility/Auth.tsx
@@ -1,19 +1,27 @@
-import React, { FC } from 'react'
-import { useQuery,useQueryClient } from 'react-query'
-import { listenAuthState } from '../../lib/auth'
+import React, { FC, useEffect } from 'react'
+import { useQuery, useQueryClient } from 'react-query'
+import { fetchAuthUser, subscribeAuthState } from '../../lib/auth'
 import { Loading } from '../utility'
 import Router from 'next/router'
 
 const Auth: FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const { data,isLoading } = useQuery('auth', () => listenAuthState())
-  if(isLoading) return <Loading/>
+  const queryClient = useQueryClient()
+  const { data, isLoading } = useQuery('auth', fetchAuthUser)
+
+  useEffect(() => {
+    const unsubscribe = subscribeAuthState((adminUser) => {
+      queryClient.setQueryData('auth', adminUser)
+    })
+    return () => unsubscribe()
+  }, [queryClient])
+
+  if (isLoading) return <Loading />
 
   if (data || Router.pathname === '/login') {
     return <>{children}</>
-  } else {
-    Router.push('/login')
-    return <></>
   }
+  Router.push('/login')
+  return <></>
 }
 
 export default Auth

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,42 +1,63 @@
+import firebase from 'firebase/app'
 import {auth,authPersistenceSession,adminsRef} from '../firebase/index'
 
 import {admin} from '../types/admin'
-import { isValidRequiredInput, isValidEmailFormat, isValidMinLength } from './validation'
+import { isValidRequiredInput, isValidEmailFormat } from './validation'
 
-export const listenAuthState = (): Promise<admin | undefined> => {
-  return new Promise((resolve, reject) => {
-    return auth.onAuthStateChanged(async (user) => {
-      if (!user) {
-        reject(undefined)
-      } else {
-        return adminsRef
-          .doc(user.uid)
-          .get()
-          .then((snapshot) => {
-            const data = snapshot.data()
-            if (!data) {
-              console.error('Does not exist user data')
-              reject(undefined)
-            } else {
-              resolve({
-                created_at: data.created_at,
-                description:data.description,
-                email:data.email,
-                image:data.image,
-                name: data.name,
-                admin_id: data.admin_id,
-                updated_at: data.updated_at,
-              })
-            }
-          })
-          .catch((error) => {
-            console.error(error)
-            reject(undefined)
-          })
-      }
-    })
+const mapAdminSnapshot = (data: firebase.firestore.DocumentData): admin => ({
+  created_at: data.created_at,
+  description: data.description,
+  email: data.email,
+  image: data.image,
+  name: data.name,
+  admin_id: data.admin_id,
+  updated_at: data.updated_at,
+})
+
+const loadAdminFromAuthUser = async (
+  user: firebase.User
+): Promise<admin | undefined> => {
+  const snapshot = await adminsRef.doc(user.uid).get()
+  const data = snapshot.data()
+  if (!data) {
+    console.error('Does not exist user data')
+    return undefined
+  }
+  return mapAdminSnapshot(data)
+}
+
+/** 初回の auth クエリ用（未ログインは undefined を返す） */
+export const fetchAuthUser = (): Promise<admin | undefined> => {
+  const user = auth.currentUser
+  if (!user) {
+    return Promise.resolve(undefined)
+  }
+  return loadAdminFromAuthUser(user).catch((error) => {
+    console.error(error)
+    return undefined
   })
 }
+
+/** Firebase 認証状態の変化を react-query に反映する */
+export const subscribeAuthState = (
+  onChange: (adminUser: admin | undefined) => void
+): (() => void) => {
+  return auth.onAuthStateChanged(async (user) => {
+    if (!user) {
+      onChange(undefined)
+      return
+    }
+    try {
+      onChange(await loadAdminFromAuthUser(user))
+    } catch (error) {
+      console.error(error)
+      onChange(undefined)
+    }
+  })
+}
+
+/** @deprecated fetchAuthUser を使用 */
+export const listenAuthState = fetchAuthUser
 
 export const logIn = ( user:{ email : string , password : string } ): Promise<string | undefined> => {
   return new Promise((resolve, reject) => {
@@ -77,4 +98,3 @@ export const logOut = (): Promise<string | undefined> => {
       })
   })
 }
-


### PR DESCRIPTION
Closes #26

## Summary
- `fetchAuthUser` / `subscribeAuthState` で認証状態を react-query に同期
- ログイン成功時に `invalidateQueries('auth')`

## Test plan
- [ ] シークレットウィンドウでログイン後、トップが表示される