### PR TITLE
fix(auth): user 未設定時の admin_id 参照でクラッシュ

### DIFF
--- a/src/components/containers/ContentContainer.tsx
+++ b/src/components/containers/ContentContainer.tsx
@@ -1,27 +1,31 @@
 import {FC} from 'react';
 import {useRouter} from 'next/router'
-import {useQuery,useQueryClient} from 'react-query'
+import {useQuery} from 'react-query'
 
 import {ContentTemplate} from '../templates'
 import {getAsString} from '../../lib/helper'
 import {fetchContent} from "../../lib/contents";
-import { admin } from "../../types/admin";
+import { Loading } from '../utility'
+import { admin } from '../../types/admin'
 
 const ContentContainer:FC = () => {
   const router = useRouter()
-  const queryClient = useQueryClient()
   const id = router.query.contentId
-  const user:admin = queryClient.getQueryData('auth')
-  const uid = user.admin_id
+  const { data: user, isLoading: authLoading } = useQuery<admin>('auth')
+  const adminId = user?.admin_id ?? ''
+
   const content = useQuery(
-    ['content',getAsString(id)],
-    () => fetchContent(uid,getAsString(id)), {
-      enabled: !!id,
-      staleTime:0
+    ['content', getAsString(id)],
+    () => fetchContent(adminId, getAsString(id)),
+    {
+      enabled: !!id && !!adminId,
+      staleTime: 0,
     }
   )
 
-  return <ContentTemplate content={content.data} uid={uid}/>
+  if (authLoading || !user) return <Loading />
+
+  return <ContentTemplate content={content.data} uid={adminId}/>
 };
 
 export default ContentContainer;

--- a/src/components/containers/LoginContainer.tsx
+++ b/src/components/containers/LoginContainer.tsx
@@ -1,17 +1,23 @@
-import {FC,useEffect} from 'react';
-import {useQueryClient} from "react-query";
+import {FC, useEffect} from 'react';
+import {useQuery} from "react-query";
 import {useRouter} from 'next/router'
 
 import {LoginTemplate} from '../../components/templates'
-import { admin } from "../../types/admin";
+import { Loading } from '../utility'
+import { admin } from '../../types/admin'
 
 const LoginContainer:FC = () => {
   const router = useRouter()
-  const queryClient = useQueryClient()
-  const user:admin = queryClient.getQueryData('auth')
-  if(user) {
-    router.push('/')
-  }
+  const { data: user, isLoading } = useQuery<admin>('auth')
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      router.push('/')
+    }
+  }, [isLoading, user, router])
+
+  if (isLoading) return <Loading />
+
   return <LoginTemplate/>
 };
 

--- a/src/components/containers/SettingContainer.tsx
+++ b/src/components/containers/SettingContainer.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
-import {useQuery,useQueryClient} from 'react-query'
+import {useQuery} from 'react-query'
 
 import {SettingTemplate} from '../templates'
 import {Loading} from '../utility'
 import {fetchHistories} from '../../lib/histories'
-import { admin } from "../../types/admin";
+import { admin } from '../../types/admin'
 
 const SettingContainer = () => {
-  const queryClient = useQueryClient()
-  const user:admin = queryClient.getQueryData('auth')
-  const history = useQuery('histories',() =>fetchHistories(user.admin_id))
+  const { data: user, isLoading: authLoading } = useQuery<admin>('auth')
+  const adminId = user?.admin_id ?? ''
+  const history = useQuery('histories', () => fetchHistories(adminId), {
+    enabled: !!adminId,
+  })
 
-  if(history.isLoading) return <Loading/>
+  if (authLoading || !user) return <Loading />
+  if (history.isLoading) return <Loading />
+
   return <SettingTemplate admin={user} histories={history.data}/>
 };
 

--- a/src/components/containers/TopContainser.tsx
+++ b/src/components/containers/TopContainser.tsx
@@ -1,16 +1,21 @@
 import {FC} from 'react';
-import {useQuery,useQueryClient} from 'react-query'
+import {useQuery} from 'react-query'
 
 import {TopTemplate} from '../templates'
 import {fetchContents} from '../../lib/contents'
-import { admin } from "../../types/admin";
+import { Loading } from '../utility'
+import { admin } from '../../types/admin'
 
 const TopContainer:FC = () => {
-  const queryClient = useQueryClient()
-  const user:admin = queryClient.getQueryData('auth')
-  const userId = user.admin_id
-  const contents = useQuery('contents', () =>fetchContents(userId) )
-  return<TopTemplate contents={contents.data}/>
+  const { data: user, isLoading: authLoading } = useQuery<admin>('auth')
+  const adminId = user?.admin_id ?? ''
+  const contents = useQuery('contents', () => fetchContents(adminId), {
+    enabled: !!adminId,
+  })
+
+  if (authLoading || !user) return <Loading />
+
+  return <TopTemplate contents={contents.data}/>
 };
 
 export default TopContainer;


### PR DESCRIPTION
Closes #27

## 依存
- #33 (`fix/issue-1-auth-session`) を **先にマージ** してから本 PR をマージしてください。

## Summary
- 各 Container で `useQuery<admin>('auth')` と Loading ガード

## Test plan（マージ前）
- [ ] `npm run build` 成功（CI / ローカル済み）
- [ ] `npm run dev` → ログイン → トップ・コンテンツ・設定が表示される
- [ ] 未ログインで保護ページに直接アクセスしてもクラッシュしない