### PR TITLE
fix(login): ログイン失敗時のエラーメッセージが不正確

### DIFF
--- a/src/components/templates/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate.tsx
@@ -18,9 +18,8 @@ const LoginTemplate:VFC = () => {
     onSuccess:() => {
       router.push('/')
     },
-    onError: (error) => {
-      const handle = error === undefined ? 'ユーザーが見つかりません。': 'ログインに失敗しました。'
-      alert(handle)
+    onError: () => {
+      alert('ログインに失敗しました。メールアドレスとパスワードを確認してください。')
     },
   })
   return (


### PR DESCRIPTION
Closes #28

## Test plan
- [ ] 誤パスワードで分かりやすい alert
- [ ] `npm run build` PASS