### PR TITLE
fix: auth timeout, histories reorder, and drag-and-drop on setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "portfolio_midori02",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.4.1",
         "@emotion/server": "^11.4.0",
@@ -169,6 +172,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "verify:dev": "bash scripts/restart-and-verify-dev.sh"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",
     "@emotion/server": "^11.4.0",

--- a/src/components/Cards/HistoryCard.tsx
+++ b/src/components/Cards/HistoryCard.tsx
@@ -3,6 +3,9 @@ import { Box , IconButton , Typography } from "@mui/material";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import BackspaceIcon from "@mui/icons-material/Backspace";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import { DraggableAttributes } from '@dnd-kit/core'
+import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
 
 import { History } from "../../types/histories";
 
@@ -12,33 +15,63 @@ type Props = {
   downRole:() => void
   history:History
   deleteFunc:() => void
+  dragHandleAttributes?: DraggableAttributes
+  dragHandleListeners?: SyntheticListenerMap
 }
 
 const HistoryCard:VFC<Props> = (props) => {
-  const {history,deleteFunc,upRole,downRole,length} = props
+  const {history,deleteFunc,upRole,downRole,length,dragHandleAttributes,dragHandleListeners} = props
   return (
     <Box
       margin={'auto'}
       width={'100%'}
       display={'flex'}
       justifyContent={'space-between'}
-      key={history.history_id}
-      sx={{":hover": {
+      alignItems={'center'}
+      sx={{
+        ':hover': {
           boxShadow: '0 5px 10px gray',
-          transform: 'translate(0, -5px)'
+          transform: 'translate(0, -5px)',
         },
-        padding:'8px 12px'
+        padding:'8px 12px',
+        backgroundColor: '#fff',
+        borderRadius: 1,
       }}
     >
-      <Box>
-        <Typography sx={{textAlign:'left'}}>
-          {`${history.year}年${history.month}月`}
-        </Typography>
-        <Typography sx={{textAlign:'left'}}>
-          {history.event}
-        </Typography>
+      <Box display="flex" alignItems="flex-start" gap={0.5} flex={1} minWidth={0}>
+        {dragHandleAttributes && dragHandleListeners && (
+          <Box
+            component="button"
+            type="button"
+            aria-label="ドラッグして並び替え"
+            sx={{
+              border: 'none',
+              background: 'none',
+              p: 0.5,
+              mt: 0.5,
+              cursor: 'grab',
+              color: 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              borderRadius: 1,
+              '&:active': { cursor: 'grabbing' },
+            }}
+            {...dragHandleAttributes}
+            {...dragHandleListeners}
+          >
+            <DragIndicatorIcon fontSize="small" />
+          </Box>
+        )}
+        <Box minWidth={0}>
+          <Typography sx={{textAlign:'left'}}>
+            {`${history.year}年${history.month}月`}
+          </Typography>
+          <Typography sx={{textAlign:'left'}}>
+            {history.event}
+          </Typography>
+        </Box>
       </Box>
-      <Box sx={{minWidth:'120px',textAlign:'end',lineHeight:4}}>
+      <Box sx={{minWidth:'120px',textAlign:'end',flexShrink:0}}>
         <IconButton
           disabled={history.role === 1}
           onClick={upRole}

--- a/src/components/Cards/HistoryList.tsx
+++ b/src/components/Cards/HistoryList.tsx
@@ -1,0 +1,173 @@
+import { VFC, useEffect, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Box, Typography } from '@mui/material'
+import { useMutation, useQueryClient } from 'react-query'
+
+import { History } from '../../types/histories'
+import { reorderHistories, moveHistory, removeHistory } from '../../lib/histories'
+import HistoryCard from './HistoryCard'
+
+type SortableItemProps = {
+  history: History
+  length: number
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onDelete: () => void
+  disabled?: boolean
+}
+
+const SortableHistoryItem: VFC<SortableItemProps> = ({
+  history,
+  length,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+  disabled,
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: history.history_id, disabled: !!disabled })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.85 : 1,
+    zIndex: isDragging ? 1 : 0,
+    position: 'relative' as const,
+  }
+
+  return (
+    <Box ref={setNodeRef} style={style}>
+      <HistoryCard
+        history={history}
+        length={length}
+        upRole={onMoveUp}
+        downRole={onMoveDown}
+        deleteFunc={onDelete}
+        dragHandleAttributes={attributes}
+        dragHandleListeners={listeners}
+      />
+    </Box>
+  )
+}
+
+type Props = {
+  adminId: string
+  histories: History[]
+}
+
+const HistoryList: VFC<Props> = ({ adminId, histories }) => {
+  const queryClient = useQueryClient()
+  const [orderedHistories, setOrderedHistories] = useState(histories)
+
+  useEffect(() => {
+    setOrderedHistories(histories)
+  }, [histories])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const invalidate = () => queryClient.invalidateQueries('histories')
+
+  const reorderMutate = useMutation(
+    (orderedIds: string[]) => reorderHistories(adminId, orderedIds),
+    {
+      onSuccess: () => invalidate(),
+      onError: () => {
+        setOrderedHistories(histories)
+        alert('順番の変更に失敗しました。')
+      },
+    }
+  )
+
+  const moveMutate = useMutation(
+    (data: { historyId: string; direction: 'up' | 'down' }) =>
+      moveHistory(adminId, data.historyId, data.direction),
+    {
+      onSuccess: () => invalidate(),
+      onError: () => alert('順番の変更に失敗しました。'),
+    }
+  )
+
+  const deleteMutate = useMutation(
+    (id: string) => removeHistory(adminId, id),
+    {
+      onSuccess: () => invalidate(),
+      onError: () => alert('削除に失敗しました。'),
+    }
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = orderedHistories.findIndex((h) => h.history_id === active.id)
+    const newIndex = orderedHistories.findIndex((h) => h.history_id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+
+    const next = arrayMove(orderedHistories, oldIndex, newIndex)
+    setOrderedHistories(next)
+    reorderMutate.mutate(next.map((h) => h.history_id))
+  }
+
+  if (orderedHistories.length === 0) {
+    return <Typography>Histories not found...</Typography>
+  }
+
+  const isBusy =
+    reorderMutate.isLoading || moveMutate.isLoading || deleteMutate.isLoading
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={orderedHistories.map((h) => h.history_id)}
+        strategy={verticalListSortingStrategy}
+      >
+        {orderedHistories.map((history) => (
+          <SortableHistoryItem
+            key={history.history_id}
+            history={history}
+            length={orderedHistories.length}
+            disabled={isBusy}
+            onMoveUp={() =>
+              moveMutate.mutate({ historyId: history.history_id, direction: 'up' })
+            }
+            onMoveDown={() =>
+              moveMutate.mutate({ historyId: history.history_id, direction: 'down' })
+            }
+            onDelete={() => deleteMutate.mutate(history.history_id)}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+export default HistoryList

--- a/src/components/Cards/index.ts
+++ b/src/components/Cards/index.ts
@@ -1,2 +1,3 @@
 export {default as ContentCard} from './ContentCard'
 export {default as HistoryCard} from './HistoryCard'
+export {default as HistoryList} from './HistoryList'

--- a/src/components/templates/SettingTemplate.tsx
+++ b/src/components/templates/SettingTemplate.tsx
@@ -7,10 +7,10 @@ import {History} from '../../types/histories'
 import {TextInput,DateInput} from '../Inputs'
 import {ImageUploader} from '../image'
 import {PrimaryButton} from "../Buttons";
-import {HistoryCard} from '../Cards'
+import {HistoryList} from '../Cards'
 import {useStringChangeEvent} from '../../lib/customHooks'
 import {updateAdmin} from '../../lib/admin'
-import {createHistory,updateHistoryRole,removeHistory} from '../../lib/histories'
+import {createHistory} from '../../lib/histories'
 import { AUTH_QUERY_KEY } from '../../lib/authQuery'
 import { normalizeImages } from '../../lib/imageUtils'
 import { ImageType } from '../../types/image'
@@ -76,25 +76,6 @@ const SettingTemplate:FC<Props> = (props) => {
     }
   )
 
-  const deleteMutate = useMutation(
-    ( data:{ adminId : string , id : string,currentNum:number,deleteNum:number }) => removeHistory(data.adminId,data.id,data.currentNum,data.deleteNum),{
-      onSuccess:() => {
-        queryClient.invalidateQueries('histories')
-      }
-    })
-
-  const historyUpdateRoleMutate = useMutation(
-    (roleData:{
-      adminId:string,
-      historyId:string,
-      update:number,
-      currentNum:number
-    }) => updateHistoryRole(roleData.adminId,roleData.historyId,roleData.update,roleData.currentNum),{
-      onSuccess:() => {
-        queryClient.invalidateQueries('histories')
-      }
-    })
-
   return (
     <Container sx={{display:'flex',minHeight:'100vh'}}>
       <Box width={'50%'} padding={'0 32px 0 16px'}>
@@ -146,35 +127,11 @@ const SettingTemplate:FC<Props> = (props) => {
       </Box>
       <Box sx={{borderLeft:'1px solid black'}} width='50%' textAlign={'center'} paddingLeft={'32px'}>
         <Typography variant={'h4'}>Histories</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          左の ≡ をドラッグして並び替え
+        </Typography>
         <Box margin={'32px 0'} >
-          {histories && histories.length > 0 ?
-            histories.map((history) => (
-              <HistoryCard
-                key={history.history_id}
-                length={histories.length}
-                upRole={() => historyUpdateRoleMutate.mutate( {
-                  adminId:history.admin_id ,
-                  historyId:history.history_id ,
-                  update:history.role - 1 ,
-                  currentNum:history.role
-                })}
-                downRole={() => historyUpdateRoleMutate.mutate( {
-                  adminId:history.admin_id ,
-                  historyId:history.history_id ,
-                  update:history.role + 1 ,
-                  currentNum:history.role
-                })}
-                history={history}
-                deleteFunc={() => deleteMutate.mutate({
-                  adminId:history.admin_id,
-                  id:history.history_id,
-                  currentNum:histories.length,
-                  deleteNum:history.role
-                })}
-              />
-            ))
-            :<Typography>Histories not found...</Typography>
-          }
+          <HistoryList adminId={admin.admin_id} histories={histories} />
         </Box>
       </Box>
     </Container>

--- a/src/components/utility/Auth.tsx
+++ b/src/components/utility/Auth.tsx
@@ -39,7 +39,7 @@ const Auth: FC<Props> = ({ children, publicRoute = false }) => {
   }
 
   if (!data) {
-    return <PageSpinner />
+    return null
   }
 
   return <>{children}</>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,9 @@ import { admin } from '../types/admin'
 import { normalizeImages } from './imageUtils'
 import { isValidRequiredInput, isValidEmailFormat } from './validation'
 
+const AUTH_HARD_TIMEOUT_MS = 12000
+const ADMIN_DOC_TIMEOUT_MS = 10000
+
 const mapAdminSnapshot = (data: firebase.firestore.DocumentData): admin => ({
   created_at: data.created_at,
   description: data.description,
@@ -15,19 +18,49 @@ const mapAdminSnapshot = (data: firebase.firestore.DocumentData): admin => ({
   updated_at: data.updated_at,
 })
 
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T | undefined> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => {
+          console.warn(`${label}: timeout after ${ms}ms`)
+          resolve(undefined)
+        }, ms)
+      }),
+    ])
+  } catch (error) {
+    console.error(error)
+    return undefined
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 const loadAdminFromAuthUser = async (
   user: firebase.User
 ): Promise<admin | undefined> => {
-  const snapshot = await adminsRef.doc(user.uid).get()
-  const data = snapshot.data()
-  if (!data) {
-    console.error('Does not exist user data for uid:', user.uid)
-    return undefined
-  }
-  return mapAdminSnapshot({
-    ...data,
-    admin_id: data.admin_id ?? user.uid,
-  })
+  return withTimeout(
+    (async () => {
+      const snapshot = await adminsRef.doc(user.uid).get()
+      const data = snapshot.data()
+      if (!data) {
+        console.error('Does not exist user data for uid:', user.uid)
+        return undefined
+      }
+      return mapAdminSnapshot({
+        ...data,
+        admin_id: data.admin_id ?? user.uid,
+      })
+    })(),
+    ADMIN_DOC_TIMEOUT_MS,
+    'loadAdminFromAuthUser'
+  )
 }
 
 /** 初回の auth クエリ用（Firebase 認証の初期化完了を待つ） */
@@ -47,8 +80,14 @@ export const fetchAuthUser = (): Promise<admin | undefined> => {
     const finish = (value: admin | undefined) => {
       if (settled) return
       settled = true
+      clearTimeout(hardTimeout)
       resolve(value)
     }
+
+    const hardTimeout = setTimeout(() => {
+      console.warn('fetchAuthUser: hard timeout, treating as logged out')
+      finish(undefined)
+    }, AUTH_HARD_TIMEOUT_MS)
 
     const current = auth.currentUser
     if (current) {
@@ -56,14 +95,8 @@ export const fetchAuthUser = (): Promise<admin | undefined> => {
       return
     }
 
-    const timeout = setTimeout(() => {
-      console.warn('fetchAuthUser: auth state timeout, treating as logged out')
-      finish(undefined)
-    }, 10000)
-
     const unsubscribe = auth.onAuthStateChanged(async (user) => {
       unsubscribe()
-      clearTimeout(timeout)
       finish(await resolveAdmin(user))
     })
   })

--- a/src/lib/histories.ts
+++ b/src/lib/histories.ts
@@ -1,167 +1,213 @@
-import {adminsRef,firebaseTimeStamp} from '../firebase/index'
-import { isValidRequiredInput } from "./validation";
+import { adminsRef, db, firebaseTimeStamp } from '../firebase/index'
+import { isValidRequiredInput } from './validation'
 
-import {History} from '../types/histories'
+import { History } from '../types/histories'
 
-export const fetchHistories = (adminId:string):Promise<History[] | undefined> => {
-  return new Promise((resolve,reject) => {
-    adminsRef
-      .doc(adminId)
-      .collection('histories')
-      .orderBy('role','asc')
-      .get()
-      .then((snapshots) => {
-        const historiesData = []
-        snapshots.forEach((snapshot) => {
-          const data = snapshot.data()
-          historiesData.push(data)
-        })
-        resolve(historiesData)
-      })
-      .catch((error) => {
-        console.error (error)
-        reject(undefined)
-      })
-  })
+const historiesCol = (adminId: string) =>
+  adminsRef.doc(adminId).collection('histories')
+
+const isRoleSequenceValid = (items: History[]): boolean => {
+  if (items.length === 0) return true
+  const sorted = [...items].sort((a, b) => a.role - b.role)
+  const roles = sorted.map((h) => h.role)
+  return (
+    new Set(roles).size === roles.length &&
+    sorted.every((h, i) => h.role === i + 1)
+  )
 }
 
-export const createHistory = (history:{
-  admin_id:string,
-  event:string,
-  year:number,
-  month:number,
-  role:number
-}):Promise<string | undefined> => {
-  return new Promise((resolve,reject) => {
-    const {event,admin_id,year,month,role} = history
+/** role を 1..n に振り直す（欠番・重複の修復） */
+export const reindexHistoryRoles = async (adminId: string): Promise<void> => {
+  const snapshots = await historiesCol(adminId).orderBy('role', 'asc').get()
+  if (snapshots.empty) return
+
+  const batch = db.batch()
+  let hasWrites = false
+  snapshots.docs.forEach((doc, index) => {
+    const newRole = index + 1
+    if (doc.data().role !== newRole) {
+      batch.set(doc.ref, { role: newRole }, { merge: true })
+      hasWrites = true
+    }
+  })
+  if (hasWrites) {
+    await batch.commit()
+  }
+}
+
+const loadHistoriesOrdered = async (adminId: string): Promise<History[]> => {
+  const snapshots = await historiesCol(adminId).orderBy('role', 'asc').get()
+  const items: History[] = []
+  snapshots.forEach((snapshot) => {
+    items.push(snapshot.data() as History)
+  })
+  return items
+}
+
+export const fetchHistories = async (
+  adminId: string
+): Promise<History[] | undefined> => {
+  try {
+    let items = await loadHistoriesOrdered(adminId)
+    if (!isRoleSequenceValid(items)) {
+      await reindexHistoryRoles(adminId)
+      items = await loadHistoriesOrdered(adminId)
+    }
+    return items
+  } catch (error) {
+    console.error(error)
+    return undefined
+  }
+}
+
+export const createHistory = (history: {
+  admin_id: string
+  event: string
+  year: number
+  month: number
+  role: number
+}): Promise<string | undefined> => {
+  return new Promise((resolve, reject) => {
+    const { event, admin_id, year, month } = history
     if (!isValidRequiredInput(event)) {
       alert('内容が未入力です。ご確認ください。')
       reject(undefined)
-      return false
+      return
     }
     if (!window.confirm('この内容で作成しますか？')) {
       reject(undefined)
-      return false
+      return
     }
-    const history_id = adminsRef.doc(admin_id).collection('histories').doc().id
-    const historyData = {
-      admin_id:admin_id,
-      created_at : firebaseTimeStamp.now(),
-      event:event,
-      history_id:history_id,
-      year:year,
-      month:month,
-      role:role,
-      updated_at:firebaseTimeStamp.now()
-    }
-    adminsRef
-      .doc(admin_id)
-      .collection('histories')
-      .doc(history_id)
-      .set(historyData)
-      .then(() => {
+
+    void (async () => {
+      try {
+        const existing = await loadHistoriesOrdered(admin_id)
+        const nextRole =
+          existing.length === 0
+            ? 1
+            : Math.max(...existing.map((h) => h.role)) + 1
+        const history_id = historiesCol(admin_id).doc().id
+        const historyData = {
+          admin_id,
+          created_at: firebaseTimeStamp.now(),
+          event,
+          history_id,
+          year,
+          month,
+          role: nextRole,
+          updated_at: firebaseTimeStamp.now(),
+        }
+        await historiesCol(admin_id).doc(history_id).set(historyData)
         resolve('created history')
-      })
-      .catch((error) => {
-        console.error (error)
+      } catch (error) {
+        console.error(error)
         reject(undefined)
-      })
+      }
+    })()
   })
 }
 
 export const removeHistory = (
   adminId: string,
-  id: string,
-  currentLength: number,
-  deleteNumber: number
+  id: string
 ): Promise<string | undefined> => {
   return new Promise((resolve, reject) => {
     if (!window.confirm('本当に削除しますか？')) {
       reject(undefined)
-      return false
+      return
     }
-    adminsRef
-      .doc(adminId)
-      .collection('histories')
-      .doc(id)
-      .delete()
-      .then(() => {
-        if (deleteNumber === currentLength) {
-          resolve('deleted')
-        } else {
-          adminsRef
-            .doc(adminId)
-            .collection('histories')
-            .where('role', '>', deleteNumber)
-            .get()
-            .then((snapshots) => {
-              snapshots.forEach((snapshot) => {
-                const data = snapshot.data()
-                adminsRef
-                  .doc(adminId)
-                  .collection('histories')
-                  .doc(data.history_id)
-                  .set({ role: data.role - 1 }, { merge: true })
-                  .then(() => {
-                    resolve('delete')
-                  })
-                  .catch((err) => {
-                    console.error(err)
-                    reject(undefined)
-                  })
-              })
-            })
-        }
-      })
-      .catch((error) => {
+
+    void (async () => {
+      try {
+        await historiesCol(adminId).doc(id).delete()
+        await reindexHistoryRoles(adminId)
+        resolve('deleted')
+      } catch (error) {
         console.error(error)
         reject(undefined)
-      })
+      }
+    })()
   })
 }
 
+export const reorderHistories = async (
+  adminId: string,
+  orderedIds: string[]
+): Promise<string | undefined> => {
+  try {
+    if (orderedIds.length === 0) return 'reordered'
+    const batch = db.batch()
+    orderedIds.forEach((id, index) => {
+      batch.set(
+        historiesCol(adminId).doc(id),
+        { role: index + 1 },
+        { merge: true }
+      )
+    })
+    await batch.commit()
+    return 'reordered'
+  } catch (error) {
+    console.error(error)
+    return undefined
+  }
+}
+
+export const moveHistory = (
+  adminId: string,
+  historyId: string,
+  direction: 'up' | 'down'
+): Promise<string | undefined> => {
+  return new Promise((resolve, reject) => {
+    void (async () => {
+      try {
+        let items = await loadHistoriesOrdered(adminId)
+        if (!isRoleSequenceValid(items)) {
+          await reindexHistoryRoles(adminId)
+          items = await loadHistoriesOrdered(adminId)
+        }
+
+        const index = items.findIndex((h) => h.history_id === historyId)
+        if (index < 0) {
+          reject(undefined)
+          return
+        }
+
+        const swapIndex = direction === 'up' ? index - 1 : index + 1
+        if (swapIndex < 0 || swapIndex >= items.length) {
+          reject(undefined)
+          return
+        }
+
+        const reordered = [...items]
+        ;[reordered[index], reordered[swapIndex]] = [
+          reordered[swapIndex],
+          reordered[index],
+        ]
+
+        const result = await reorderHistories(
+          adminId,
+          reordered.map((item) => item.history_id)
+        )
+        if (!result) {
+          reject(undefined)
+          return
+        }
+        resolve('moved')
+      } catch (error) {
+        console.error(error)
+        reject(undefined)
+      }
+    })()
+  })
+}
+
+/** @deprecated moveHistory を使用 */
 export const updateHistoryRole = (
   adminId: string,
   historyId: string,
   update: number,
   currentNum: number
 ): Promise<string | undefined> => {
-  return new Promise((resolve, reject) => {
-    adminsRef
-      .doc(adminId)
-      .collection('histories')
-      .where('role', '==', update)
-      .get()
-      .then((snapshots) => {
-        const orderRole = []
-        snapshots.forEach((snapshot) => {
-          const data = snapshot.data()
-          orderRole.push(data)
-        })
-        const changeRoleId = orderRole[0].history_id
-        adminsRef
-          .doc(adminId)
-          .collection('histories')
-          .doc(changeRoleId)
-          .set({ role: currentNum }, { merge: true })
-          .then(() => {
-            adminsRef
-              .doc(adminId)
-              .collection('histories')
-              .doc(historyId)
-              .set({ role: update }, { merge: true })
-              .then(() => {
-                resolve('updated role')
-              })
-              .catch((error) => {
-                console.error(error)
-                reject(undefined)
-              })
-          })
-      })
-      .catch((error) => {
-        console.error(error)
-        reject(undefined)
-      })
-  })
+  const direction = update < currentNum ? 'up' : 'down'
+  return moveHistory(adminId, historyId, direction)
 }


### PR DESCRIPTION
## Summary

- **認証** — Firestore 読み取りが返らない場合のタイムアウト（無限ローディング防止）
- **Histories** — `role` 欠番・重複の自動修復、↑↓ ボタンの並び替え修正
- **Histories DnD** — ≡ ハンドルでドラッグ＆ドロップ並び替え（@dnd-kit）

## Test plan

- [x] `npm run verify:build` — PASS
- [x] `npm run verify:dev` — 6/6 ルート PASS
- [ ] マージ後 Vercel Production = Ready
- [ ] 本番 `/setting` で Histories の DnD・↑↓ が反映される
- [ ] 本番 `/` で無限ローディングが起きない

## コミット

`05df1b0` fix: auth timeout, histories reorder, and drag-and-drop on setting